### PR TITLE
chore:add lost deps & add ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+- docker pull fibjs/fibjs:ci
+- dir=`pwd` ;docker run -it -v ${dir}:/home/ci  fibjs/fibjs:ci sh /home/ci-script

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 ## Object Relational Mapping for fibjs
 
+[![Build Status](https://travis-ci.org/xicilion/fib-orm.svg)](https://travis-ci.org/xicilion/fib-orm)
+
 ## Install
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -8,9 +8,16 @@
     "homepage": "https://github.com/xicilion/fib-orm",
     "license": "MIT",
     "scripts": {
-        "test": "fibjs test/main.js"
+        "ci": "fibjs test/main.js"
     },
     "dependencies": {
         "orm": "^3.2.2"
+    },
+    "devDependencies": {
+        "@fibjs/ci": "^1.0.0",
+        "lodash": "^4.17.4"
+    },
+    "ci": {
+        "type": "travis"
     }
 }


### PR DESCRIPTION
ci 需要在github上添加 travis-ci 的钩子服务才可以开启